### PR TITLE
Add Netlify configuration for Next.js standalone build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = ".next/standalone"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
This pull request adds the necessary Netlify configuration for building a Next.js standalone application. The `netlify.toml` file is included with the `build` command set to `npm run build` and the `publish` directory set to `.next/standalone`. Additionally, the `@netlify/plugin-nextjs` plugin is added to the configuration. This will enable the deployment of the Next.js application on Netlify.