### PR TITLE
Fix deprecation warning for motion()

### DIFF
--- a/src/components/blog/SideNavigation.jsx
+++ b/src/components/blog/SideNavigation.jsx
@@ -3,12 +3,14 @@ import { useEffect, useRef, useState } from "react";
 
 const NUM_LINES = 30; // Adjust this as needed
 
+const MotionNav = motion.create("nav");
+
 const SideNavigation = ({ blogEntries, onNavigate }) => {
   const [isHovered, setIsHovered] = useState(false);
   const mouseY = useMotionValue(Infinity);
 
   return (
-    <motion.nav
+    <MotionNav
       onMouseMove={(e) => {
         mouseY.set(e.clientY);
         setIsHovered(true);
@@ -31,7 +33,7 @@ const SideNavigation = ({ blogEntries, onNavigate }) => {
           />
         );
       })}
-    </motion.nav>
+    </MotionNav>
   );
 };
 
@@ -49,11 +51,9 @@ const LinkLine = ({ mouseY, isHovered, title, onClick }) => {
     return val - (bounds?.y || 0) - (bounds?.height || 0) / 2;
   });
 
-  // Styles for non-link lines
   const lineWidthRaw = useTransform(distance, [-80, 0, 80], [15, 100, 15]);
   const lineWidth = useSpring(lineWidthRaw, SPRING_OPTIONS);
 
-  // Styles for link lines
   const linkWidth = useSpring(25, SPRING_OPTIONS);
 
   useEffect(() => {

--- a/src/components/buttons/SpringModal.jsx
+++ b/src/components/buttons/SpringModal.jsx
@@ -1,6 +1,8 @@
 import { AnimatePresence, motion } from "framer-motion";
 import CodeBlockWithCopy from "./CodeBlockWithCopy";
 
+const MotionDiv = motion.create("div");
+
 const SpringModal = ({ isOpen, setIsOpen }) => {
   return (
     <AnimatePresence>
@@ -12,9 +14,9 @@ const SpringModal = ({ isOpen, setIsOpen }) => {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.3 }}>
-          <motion.div
+          <MotionDiv
             className="bg-zinc-800 p-4 rounded-md shadow-md relative w-full max-w-md mx-4 cursor-default"
-            onClick={(e) => e.stopPropagation()} // Prevent closing when clicking inside modal
+            onClick={(e) => e.stopPropagation()}
             initial={{ scale: 0.5, rotate: "12deg" }}
             animate={{ scale: 1, rotate: "0deg" }}
             exit={{ scale: 0.5, rotate: "0deg" }}>
@@ -30,7 +32,7 @@ const SpringModal = ({ isOpen, setIsOpen }) => {
             <CodeBlockWithCopy
               code={`gsettings set org.gnome.mutter experimental-features '["scale-monitor-framebuffer", "xwayland-native-scaling"]'`}
             />
-          </motion.div>
+          </MotionDiv>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/nav/SideBarLink.jsx
+++ b/src/components/nav/SideBarLink.jsx
@@ -1,8 +1,7 @@
-// SideBarLink.jsx
 import { motion } from "framer-motion";
 import Link from "next/link";
 
-const MotionLink = motion(Link);
+const MotionLink = motion.create(Link);
 
 export const SideBarLink = ({ setSelected, selected, children, href, value }) => {
   return (

--- a/src/components/projects/Project.jsx
+++ b/src/components/projects/Project.jsx
@@ -49,12 +49,11 @@ export const Project = ({ modalContent, projectLink, description, imgSrc, title,
           <Image
             src={imgSrc}
             alt={`An image of the ${title} project.`}
-            layout="fill"
-            objectFit="cover"
-            objectPosition="top"
-            className="absolute top-0 left-0"
-            placeholder="blur" // Enables blurred placeholder
-            blurDataURL={blurDataURL} // Sets the blurred image
+            fill
+            className="absolute top-0 left-0 object-cover object-top"
+            placeholder="blur"
+            blurDataURL={blurDataURL}
+            unoptimized={imgSrc.endsWith("pokebattle.webp")}
           />
         </div>
         <div className="mt-6">
@@ -94,6 +93,7 @@ export const Project = ({ modalContent, projectLink, description, imgSrc, title,
         title={title}
         code={code}
         tech={tech}
+        blurDataURL={blurDataURL}
       />
     </>
   );


### PR DESCRIPTION
This pull request fixes the deprecation warning for the `motion()` function by replacing it with `motion.create()`. The warning message "motion() is deprecated. Use motion.create() instead" is no longer displayed.