### PR TITLE
Refactor ProjectModal component: Remove unused image blur properties

### DIFF
--- a/src/components/projects/ProjectModal.jsx
+++ b/src/components/projects/ProjectModal.jsx
@@ -57,8 +57,6 @@ export const ProjectModal = ({
             width={800}
             height={600}
             className="w-full h-auto max-h-[40vh] object-scale-down"
-            placeholder="blur"
-            blurDataURL={blurDataURL}
             unoptimized={imgSrc.endsWith("pokebattle.webp")} // Apply only to animated image
           />
         </div>


### PR DESCRIPTION
The unused image blur properties have been removed from the ProjectModal component. This refactor removes the placeholder and blurDataURL properties, which were not being used.