### PR TITLE
Remove unused image preloading code in Project.jsx

### DIFF
--- a/src/components/projects/Project.jsx
+++ b/src/components/projects/Project.jsx
@@ -23,16 +23,6 @@ export const Project = ({ modalContent, projectLink, description, imgSrc, title,
     }
   }, [isInView, controls]);
 
-  // Preload the modal images after the component mounts
-  useEffect(() => {
-    const imagesToPreload = [imgSrc];
-
-    imagesToPreload.forEach((src) => {
-      const img = new Image();
-      img.src = src;
-    });
-  }, [imgSrc]);
-
   return (
     <>
       <MotionDiv


### PR DESCRIPTION
This pull request removes the unused image preloading code in the Project.jsx file. The code was responsible for preloading the modal images after the component mounts, but it is no longer needed. This change improves the codebase by removing unnecessary code.