### PR TITLE
Change font of blog to Inter

### DIFF
--- a/src/pages/blog.jsx
+++ b/src/pages/blog.jsx
@@ -1,7 +1,14 @@
+import { Inter } from 'next/font/google';
 import Blog from '../components/blog/Blog';
 
+const inter = Inter({ subsets: ['latin'] });
+
 const BlogPage = () => {
-  return <Blog />;
+  return (
+    <main className={inter.className}>
+      <Blog />
+    </main>
+  );
 };
 
 export default BlogPage;


### PR DESCRIPTION
This pull request changes the font of the blog from system-ui to the Inter font from the portfolio. The `BlogPage` component now imports the `Inter` font from `next/font/google` and applies it to the `main` element wrapping the `Blog` component. This update improves the visual consistency and enhances the typography of the blog.