### PR TITLE
Fix mobile-friendly image sizes and reveal width

### DIFF
--- a/src/components/blog/entries/AdjustingProgramsToUseWayland.jsx
+++ b/src/components/blog/entries/AdjustingProgramsToUseWayland.jsx
@@ -47,7 +47,7 @@ const AdjustingProgramsToUseWayland = () => {
         <Image
           src="/project-imgs/blurry-cut.avif"
           alt="Chromium on Wayland vs XWayland in 2019"
-          sizes="100vw"
+          sizes="100svw"
           style={{
             width: '75%',
             height: 'auto',

--- a/src/components/projects/Project.jsx
+++ b/src/components/projects/Project.jsx
@@ -66,7 +66,7 @@ export const Project = ({ modalContent, projectLink, description, imgSrc, title,
           />
         </div>
         <div className="mt-6">
-          <Reveal width="w-full">
+          <Reveal width="w-90">
             <div className="flex w-full items-center gap-2">
               <h4 className="max-w-[calc(100%_-_150px)] shrink-0 text-lg font-bold">{title}</h4>
               <div className="h-[1px] w-full bg-zinc-600" />


### PR DESCRIPTION
The pull request fixes the mobile-friendly image sizes and the reveal width in the project component. The image sizes were corrected to "100svw" and the reveal width was changed to "w-90".