### PR TITLE
Disable user selection in image modals

### DIFF
--- a/src/components/buttons/ImageModal.jsx
+++ b/src/components/buttons/ImageModal.jsx
@@ -27,6 +27,7 @@ const ImageModal = ({ isOpen, setIsOpen }) => {
             width={1200} // Use actual width of the image
             height={612} // Use actual height of the image
             className="rounded-lg"
+            style={{ userSelect: 'none' }}
           />
           {/* Close button with hover effect */}
           <button

--- a/src/components/projects/ProjectModal.jsx
+++ b/src/components/projects/ProjectModal.jsx
@@ -63,7 +63,7 @@ export const ProjectModal = ({ modalContent, projectLink, setIsOpen, imgSrc, isO
             alt={`An image of the ${title} project.`}
             fill
             sizes="(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            style={{ objectFit: 'contain' }} // Ensures the image fits without cropping
+            style={{ objectFit: 'contain', userSelect: 'none' }} // Ensures the image fits without cropping
             unoptimized={imgSrc.endsWith('pokebattle.avif')}
           />
         </div>


### PR DESCRIPTION
This pull request refactors the image modals to disable user selection. The `userSelect` CSS property is added to the image styles in both the `ImageModal` and `ProjectModal` components to prevent users from selecting the images.