### PR TITLE
Make modal transition faster

### DIFF
--- a/src/components/projects/ProjectModal.jsx
+++ b/src/components/projects/ProjectModal.jsx
@@ -55,7 +55,7 @@ export const ProjectModal = ({ modalContent, projectLink, setIsOpen, imgSrc, isO
         variants={modalAnimation}
         initial="hidden"
         animate={isOpen ? 'visible' : 'hidden'}
-        transition={{ duration: 0.5 }}>
+        transition={{ duration: 0.3 }}>
         {/* Image container */}
         <div className="relative h-64 w-full md:h-96">
           <Image


### PR DESCRIPTION
The modal transition duration has been reduced from 0.5 seconds to 0.3 seconds, making the modal feel more snappy.